### PR TITLE
added one source for receiving credentials

### DIFF
--- a/installation/neu-installation/installation-vorbereiten.rst
+++ b/installation/neu-installation/installation-vorbereiten.rst
@@ -17,7 +17,7 @@ Für die Neu-Installation des OXID eShop wird Composer benötigt. Eine Anleitung
 
 Die Shopdateien werden durch Composer bereitgestellt. Abhängig von der Shop-Edition müssen dafür unterschiedliche Kommandos in der Shell ausgeführt werden. Die Shopdateien werden in einem Unterverzeichnis gespeichert, welches im Kommando mit :command:`your_project_name` angegeben wird. Dabei wird von dem Verzeichnis ausgegangen, in dem das Kommando in der Shell abgesetzt wird. Der Parameter :command:`--no-dev` wird angegeben, wenn die entwicklungsbezogenen Dateien nicht benötigt werden.
 
-.. hint:: Für die Installation der Professional und Enterprise Edition benötigen Sie zusätzlich die Zugangsdaten, die Sie mit der E-Mail zum aktuellen Release erhalten haben.
+.. hint:: Für die Installation der Professional und Enterprise Edition benötigen Sie zusätzlich die Zugangsdaten, die Sie mit der E-Mail nach dem Kauf oder zum aktuellen Release erhalten haben.
 
 Community Edition
 ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
credentials are provided directly after the purchase or by a release mail.