### PR TITLE
Update update-from-6.1.x-to-6.2.0.rst

### DIFF
--- a/installation/update/update-from-6.1.x-to-6.2.0.rst
+++ b/installation/update/update-from-6.1.x-to-6.2.0.rst
@@ -68,7 +68,7 @@ In this step, settings and activation status of the modules belonging to the sho
 
 .. code:: bash
 
-   composer require --no-update oxid-esales/oxideshop-update-component
+   composer require --no-update oxid-esales/oxideshop-update-component:"^1.0"
    composer update --no-dev --no-interaction
 
 2. A default configuration is created for all modules located in the :file:`source/modules` directory. To do this, the new OXID eShop Console is called with the following command:


### PR DESCRIPTION
If you set minimum-stability to "dev" in your composer.json and run

composer require --no-interaction oxid-esales/oxideshop-update-component

the dev-master of the update-component will be installed, which can't handle the update process (at the moment). You must use a stable version. For this reason, require the package with a version constraint:

composer require --no-interaction oxid-esales/oxideshop-update-component:"^1.0"

This results in a stable installation and therefore a successfull update.

please also check de