### PR TITLE
Update memcached.rst

### DIFF
--- a/konfiguration/caching/memcached.rst
+++ b/konfiguration/caching/memcached.rst
@@ -9,4 +9,7 @@ Installieren Sie Memcached auf einem Server. Die Software erhalten Sie auf der W
 
 Stellen Sie sicher, dass die PHP-Bibliothek \"memcached\" aktiv ist.
 
+Weitere Vorrausetzungen
+------------
+Es wird ein Lizenz-Key mit Hochlastoption benötigt.
 .. Intern: oxbacc, Status:


### PR DESCRIPTION
Es fehlt Hinweis darauf, dass der entsprechende Lizenzkey mit Hochlastoption vorausgesetzt wird.