### PR TITLE
Changed file editing to command use

### DIFF
--- a/installation/update/standard-update.rst
+++ b/installation/update/standard-update.rst
@@ -17,8 +17,10 @@ Beispiel für ein Update einer Community Edition 6.2.0 zu 6.2.1:
 .. code:: bash
 
    composer require --no-update oxid-esales/oxideshop-metapackage-ce:v6.2.1
-   
-.. hint:: Der Name des Metapackage muss an die verwendeten Shop Edition angepasst werden.
+
+.. hint::
+
+   Der Name des Metapackage muss an die verwendeten Shop Edition angepasst werden.
 
 |schritt| Abhängigkeiten aktualisieren
 --------------------------------------

--- a/installation/update/standard-update.rst
+++ b/installation/update/standard-update.rst
@@ -10,7 +10,15 @@ Das Update sollte immer erst in einer Testumgebung, einer Kopie Ihres aktuellen 
 
 |schritt| Update-Ziel vorgeben
 ------------------------------
-In die Datei :file:`composer.json`, die sich im Hauptverzeichnis des Shops befindet, muss die Version eingetragen werden, auf welche aktualisiert werden soll. Öffnen Sie die Datei in einem Editor und tragen Sie die gewünschte Version für das Metapackage ein. Beispiel: ``"oxid-esales/oxideshop-metapackage-ce": "^v6.2.0",``
+In der Datei :file:`composer.json`, die sich im Hauptverzeichnis des Shops befindet, muss die Version des Metapackage aktualisiert werden.
+
+Beispiel für ein Update einer Community Edition 6.2.0 zu 6.2.1:
+
+.. code:: bash
+
+   composer require --no-update oxid-esales/oxideshop-metapackage-ce:v6.2.1
+   
+.. hint:: Der Name des Metapackage muss an die verwendeten Shop Edition angepasst werden.
 
 |schritt| Abhängigkeiten aktualisieren
 --------------------------------------


### PR DESCRIPTION
It's always recommended to use Composer commands instead of editing the composer.json manually.

Also the example wasn't selected wisely. This documentation part describes all update from 6.2.x to 6.2.y, but the example showed metapackage in version 6.2.0, which leads to the case you are on 6.1.x before. This use case is described in another section since it involves some more steps.