### PR TITLE
/var folder needs write permissions

### DIFF
--- a/installation/new-installation/preparing-for-installation.rst
+++ b/installation/new-installation/preparing-for-installation.rst
@@ -51,7 +51,8 @@ The HTTP server requires write access to the following directories and their sub
 :file:`/source/log/` |br|
 :file:`/source/out/pictures/` |br|
 :file:`/source/out/media/` |br|
-:file:`/source/tmp/`
+:file:`/source/tmp/` |br|
+:file:`/var/`
 
 For the web-based setup, the HTTP server must have write access to the following directory and files:
 


### PR DESCRIPTION
/var folder needs write permissions. Web setup would not let you start if var folder is not writeable.