### PR TITLE
Add update from 6.2.x to 6.3.0

### DIFF
--- a/installation/update/index.rst
+++ b/installation/update/index.rst
@@ -6,3 +6,4 @@ Update
 
    update
    standard-update
+   von-6.2.x-auf-6.3.0-aktualisieren

--- a/installation/update/standard-update.rst
+++ b/installation/update/standard-update.rst
@@ -1,7 +1,7 @@
 Standard-Update
 ===============
 
-Dieses Dokument beschreibt Patch- und Minor-Updates des OXID eShop. Mit den folgenden Schritten wird die Compilation von einer bestehenden Version 6.3.x auf eine höhere Version 6.3.x aktualisiert.
+Dieses Dokument beschreibt Patch-Updates des OXID eShop. Mit den folgenden Schritten wird die Compilation von einer bestehenden Version 6.3.x auf eine höhere Version 6.3.x aktualisiert.
 
 Das Update sollte immer erst in einer Testumgebung, einer Kopie Ihres aktuellen Shops, ausgeführt werden. Erstellen Sie zuvor eine Sicherung der Shopdateien und der Datenbank. Deaktivieren Sie alle Module und prüfen Sie, ob der Shop prinzipiell funktioniert. Testen Sie nach dem Update den Shop erneut und legen Sie dabei besonderen Wert auf die Funktionen des Bestellprozesses, auf Zahlungs- und Versandarten.
 
@@ -12,11 +12,11 @@ Das Update sollte immer erst in einer Testumgebung, einer Kopie Ihres aktuellen 
 ------------------------------
 In der Datei :file:`composer.json`, die sich im Hauptverzeichnis des Shops befindet, muss die Version des Metapackage aktualisiert werden.
 
-Beispiel für ein Update einer Community Edition 6.2.4 zu 6.3.0:
+Beispiel für ein Update einer Community Edition 6.3.0 zu 6.3.1:
 
 .. code:: bash
 
-   composer require --no-update oxid-esales/oxideshop-metapackage-ce:v6.3.0
+   composer require --no-update oxid-esales/oxideshop-metapackage-ce:v6.3.1
 
 .. hint::
 

--- a/installation/update/update.rst
+++ b/installation/update/update.rst
@@ -7,8 +7,13 @@ Dieser Abschnitt der Anwenderdokumentation informiert über das Update des OXID 
 
 Standard-Update
 ---------------
-**Inhalte:** Patch- und Minor-Update ab Version 6.3.0, Zielversion des Updates, composer.json, Abhängigkeiten aktualisieren, composer update --no-plugins --no-scripts --no-dev, neue Compilation beziehen, composer update --no-dev, Datenbank migrieren |br|
+**Inhalte:** Patch-Update ab Version 6.3.0, Zielversion des Updates, composer.json, Abhängigkeiten aktualisieren, composer update --no-plugins --no-scripts --no-dev, neue Compilation beziehen, composer update --no-dev, Datenbank migrieren |br|
 :doc:`Artikel lesen <standard-update>` |link|
+
+Von 6.2.x auf 6.3.0 aktualisieren
+---------------------------------
+**Inhalte:** Minor-Update von Version 6.2.x auf 6.3.0, Zielversion des Updates, composer.json, Abhängigkeiten aktualisieren, composer update --no-plugins --no-scripts --no-dev, neue Compilation beziehen, composer update --no-dev, Datenbank migrieren |br|
+:doc:`Artikel lesen <von-6.2.x-auf-6.3.0-aktualisieren>` |link|
 
 
 .. Intern: oxbahv, Status:

--- a/installation/update/von-6.2.x-auf-6.3.0-aktualisieren.rst
+++ b/installation/update/von-6.2.x-auf-6.3.0-aktualisieren.rst
@@ -28,7 +28,7 @@ Anschließend müssen noch manche Versionen im ``require-dev`` Bereich aktualisi
 
    composer require --dev --no-update oxid-esales/testing-library:^v8.0.0 oxid-esales/oxideshop-ide-helper:^v4.1.0
 
-.. hint::
+.. warning::
 
    Auch wenn die Dev Pakete nicht installiert werden, prüft Composer deren Abhängigkeiten. Diese Anpassung ist somit zwingend notwendig.
 

--- a/installation/update/von-6.2.x-auf-6.3.0-aktualisieren.rst
+++ b/installation/update/von-6.2.x-auf-6.3.0-aktualisieren.rst
@@ -1,0 +1,62 @@
+Von 6.2.x auf 6.3.0 aktualisieren
+=================================
+
+Dieses Dokument beschreibt ein Minor-Update des OXID eShop. Mit den folgenden Schritten wird die Compilation von einer bestehenden Version 6.2.x auf die Version 6.3.0 aktualisiert.
+
+Das Update sollte immer erst in einer Testumgebung, einer Kopie Ihres aktuellen Shops, ausgeführt werden. Erstellen Sie zuvor eine Sicherung der Shopdateien und der Datenbank. Deaktivieren Sie alle Module und prüfen Sie, ob der Shop prinzipiell funktioniert. Testen Sie nach dem Update den Shop erneut und legen Sie dabei besonderen Wert auf die Funktionen des Bestellprozesses, auf Zahlungs- und Versandarten.
+
+.. |schritt| image:: ../../media/icons/schritt.jpg
+              :class: no-shadow
+
+|schritt| Update-Ziel vorgeben
+------------------------------
+In der Datei :file:`composer.json`, die sich im Hauptverzeichnis des Shops befindet, muss die Version des Metapackage aktualisiert werden.
+
+Beispiel für ein Update einer Community Edition 6.2.4 zu 6.3.0:
+
+.. code:: bash
+
+   composer require --no-update oxid-esales/oxideshop-metapackage-ce:v6.3.0
+
+.. hint::
+
+   Der Name des Metapackage muss an die verwendeten Shop Edition angepasst werden.
+
+Anschließend müssen noch manche Versionen im ``require-dev`` Bereich aktualisiert werden.
+
+.. code:: bash
+
+   composer require --dev --no-update oxid-esales/testing-library:^v8.0.0 oxid-esales/oxideshop-ide-helper:^v4.1.0
+
+.. hint::
+
+   Auch wenn die Dev Pakete nicht installiert werden, prüft Composer deren Abhängigkeiten. Diese Anpassung ist somit zwingend notwendig.
+
+|schritt| Abhängigkeiten aktualisieren
+--------------------------------------
+Öffnen Sie eine Shell im Hauptverzeichnis des Shops und führen Sie den nachstehenden Composer-Befehl aus. Dadurch werden alle benötigten Bibliotheken aktualisiert. Der Parameter :command:`--no-dev` wird angegeben, wenn die entwicklungsbezogenen Dateien nicht benötigt werden.
+
+.. code:: bash
+
+   composer update --no-plugins --no-scripts --no-dev
+
+|schritt| Neue Compilation beziehen
+-----------------------------------
+Mit einem zweiten Composer-Befehl werden alle Scripts ausgeführt, um die neue Compilation zu beziehen. Für Shopdateien, Themes und Module muss jeweils bestätigt werden, dass das Update bestehende Dateien überschreibt.
+
+.. code:: bash
+
+   composer update --no-dev
+
+|schritt| Datenbank migrieren
+-----------------------------
+Der dritte und letzte Composer-Befehl führt die Migration der Datenbank aus, falls dies erforderlich ist.
+
+.. code:: bash
+
+   vendor/bin/oe-eshop-db_migrate migrations:migrate
+
+Damit ist das Update beendet.
+
+
+.. Intern: oxbaix, Status:


### PR DESCRIPTION
The update from 6.2.x to 6.3.0 is not described specifically in the docs. However, it differs from an update within the 6.3.x release. Due to major version changes of Testing Library and Namespace Generator the dev requirements need to be adapted to run an update successfully. Therefore I added a new page like it is done for 6.1.x to 6.2.0 before.