### PR TITLE
removing register of a repository

### DIFF
--- a/installation/new-installation/setup-command-line.rst
+++ b/installation/new-installation/setup-command-line.rst
@@ -38,10 +38,7 @@ Example
 
 .. code:: bash
 
-   composer config repositories.oxid-esales/oxideshop-demodata-ce vcs https://github.com/OXID-eSales/oxideshop_demodata_ce
-   composer require oxid-esales/oxideshop-demodata-ce:v7.0.0
-
-   vendor/bin/oe-console oe:setup:demodata
+   ./vendor/bin/oe-console oe:setup:demodata
 
 |schritt| Creating a shop administrator
 ---------------------------------------


### PR DESCRIPTION
The documentation states to install the shop via the command create-project which uses the metapackages which themselves, register the demodata packages. No need to register them before executing the command to install the demodata.