### PR TITLE
7.0 requires PHP 8.1 and not 8.0

### DIFF
--- a/installation/neu-installation/server-und-systemvoraussetzungen.rst
+++ b/installation/neu-installation/server-und-systemvoraussetzungen.rst
@@ -64,7 +64,7 @@ Das Transaction Isolation Level muss serverseitig beim Standardwert *REPEATABLE 
 PHP
 ---
 
-* PHP Versionen 8.0 oder 8.1
+* PHP Versionen 8.1
 * Empfohlen wird ein *memory_limit* von 60 MB, mindestens aber 32 MB
 * Die PHP-Einstellung *session.auto_start* in der Datei :file:`php.ini` sollte deaktiviert sein (OFF)
 * Datei-Uploads sollten in PHP aktiviert sein


### PR DESCRIPTION
- oxideshop-ce 7.0.5 (which Composer selects from ~7.0.0) requires symfony/yaml ^6.0.
- symfony/yaml v6.4.40 requires PHP 8.1+.
- Result: Composer cannot install OXID-CE 7.0.5 on PHP 8.0, even though the OXID documentation promises PHP 8.0 support.