### PR TITLE
7.4.2 release notes (de): fix the 7.4.0/7.4.1 cross-references

### DIFF
--- a/releases/oxid-eshop-742.rst
+++ b/releases/oxid-eshop-742.rst
@@ -71,8 +71,9 @@ Kompatible OXID Erweiterungen
 
 Die kompatiblen OXID Erweiterungen entsprechen denen der
 Version 7.4.0 bzw. 7.4.1. Weitere Informationen finden Sie in den Release Notes der
-OXID eShop Compilation `7.4.0 <oxid-eshop-740>` bzw.
-`7.4.1 <oxid-eshop-741>`.
+OXID eShop Compilation
+`7.4.0 <https://docs.oxid-esales.com/eshop/de/7.4/releases/oxid-eshop-740.html>`_ bzw.
+`7.4.1 <https://docs.oxid-esales.com/eshop/de/7.4/releases/oxid-eshop-741.html>`_.
 
 Update
 ------


### PR DESCRIPTION
The links to the 7.4.0 and 7.4.1 release notes do not work on the 7.4.2 page. Found while reviewing the preview docs.

## Current state

`releases/oxid-eshop-742.rst`, section "Kompatible OXID Erweiterungen":

```rst
OXID eShop Compilation `7.4.0 <oxid-eshop-740>` bzw.
`7.4.1 <oxid-eshop-741>`.
```

There is no trailing underscore, so this is not a hyperlink but interpreted text. docutils 0.18.1 renders it as:

```html
<p>OXID eShop Compilation <cite>7.4.0 &lt;oxid-eshop-740&gt;</cite> bzw.</p>
```

The reader sees the raw target including the angle brackets, and gets no link:

> Weitere Informationen finden Sie in den Release Notes der OXID eShop Compilation 7.4.0 <oxid-eshop-740> bzw. 7.4.1 <oxid-eshop-741>.

## Target state

```rst
OXID eShop Compilation
`7.4.0 <https://docs.oxid-esales.com/eshop/de/7.4/releases/oxid-eshop-740.html>`_ bzw.
`7.4.1 <https://docs.oxid-esales.com/eshop/de/7.4/releases/oxid-eshop-741.html>`_.
```

Renders as a real link:

```html
<a class="reference external" href="https://docs.oxid-esales.com/eshop/de/7.4/releases/oxid-eshop-740.html">7.4.0</a>
```

## Why absolute URLs

That is how this docset links to sibling release notes elsewhere, for example the B2B link in `releases/oxid-eshop-741.rst`. Neither `:doc:` nor `:ref:` appears anywhere in these 40 rst files, so following the existing style rather than introducing a new one.

Both targets were checked: `.../de/7.4/releases/oxid-eshop-740.html` and `...-741.html` answer 200, while the extension-less variants answer 404.

The English page has the same defect with a different symptom, fixed separately because the language lives on its own branch.