### PR TITLE
7.4.2 release notes (en): fix the 7.4.0/7.4.1 cross-references

### DIFF
--- a/releases/oxid-eshop-742.rst
+++ b/releases/oxid-eshop-742.rst
@@ -69,8 +69,9 @@ Compatible OXID Extensions
 
 The compatible OXID extensions are the same as for versions
 7.4.0 and 7.4.1. For more information, see the Release Notes
-for OXID eShop Compilation `7.4.0 <oxid-eshop-740>`_ and
-`7.4.1 <oxid-eshop-741>`_.
+for OXID eShop Compilation
+`7.4.0 <https://docs.oxid-esales.com/eshop/en/7.4/releases/oxid-eshop-740.html>`_ and
+`7.4.1 <https://docs.oxid-esales.com/eshop/en/7.4/releases/oxid-eshop-741.html>`_.
 
 Update
 ------


### PR DESCRIPTION
The links to the 7.4.0 and 7.4.1 release notes on the 7.4.2 page point at a path that does not exist. Found while reviewing the preview docs.

## Current state

`releases/oxid-eshop-742.rst`, section "Compatible OXID Extensions":

```rst
for OXID eShop Compilation `7.4.0 <oxid-eshop-740>`_ and
`7.4.1 <oxid-eshop-741>`_.
```

The trailing underscore is there, so this does become a hyperlink, but the target is a bare relative path. docutils 0.18.1 renders:

```html
<a class="reference external" href="oxid-eshop-740">7.4.0</a>
```

The built page is `releases/oxid-eshop-740.html`, so the link misses the extension. Checked against the live docs:

```
https://docs.oxid-esales.com/eshop/en/7.4/releases/oxid-eshop-740.html   200
https://docs.oxid-esales.com/eshop/en/7.4/releases/oxid-eshop-740        404
```

The link is therefore dead, silently: it looks like a link and leads nowhere.

## Target state

```rst
for OXID eShop Compilation
`7.4.0 <https://docs.oxid-esales.com/eshop/en/7.4/releases/oxid-eshop-740.html>`_ and
`7.4.1 <https://docs.oxid-esales.com/eshop/en/7.4/releases/oxid-eshop-741.html>`_.
```

## Why absolute URLs

That is how this docset links to sibling release notes elsewhere, for example the B2B link in `releases/oxid-eshop-741.rst`. Neither `:doc:` nor `:ref:` appears anywhere in these 40 rst files, so following the existing style rather than introducing a new one.

The German page carries the same defect with a worse symptom, the missing underscore makes it render as literal text. Fixed separately because the language lives on its own branch.